### PR TITLE
Work around a race condition where multiple AFL instances bind to the same CPU

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 const MAXFUZZERS = 256
@@ -141,6 +142,8 @@ func main() {
 
 	// launch the rest
 	for i := 1; i < *flagNum; i++ {
+		// To avoid multiple AFL instances binding to the same CPU, we wait a bit
+		time.Sleep(250 * time.Millisecond)
 		name := baseName + "-" + "S" + strconv.Itoa(i)
 		spawn(name, append(baseArgs, "-S", name))
 	}


### PR DESCRIPTION
This is the same issue @genewitch found and I can confirm it is also a problem on 64-core machines as well. The issue is that multiple instances of AFL will bind to the the same core. To see this in action:
head -n 25 $OUTPUT_DIR/$TARGET/*/afl-launch.log | grep binding | sort

I also did some experimentation and a 100 ms delay still resulted in two threads binding to CPU #0, but a 250 ms delay seems to reliably avoid any CPU contention.